### PR TITLE
Change the URL to the master file

### DIFF
--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -20,7 +20,7 @@ Downloader::loadMirrors()
 
 	// ASSUMPTION: All mirrors host packages for all architectures
 	// ASSUMPTION: Updates.xml is the core file
-	QNetworkRequest req(QUrl("http://download.qt-project.org/online/qtsdkrepository/windows_x86/root/qt/Updates.xml.mirrorlist"));
+	QNetworkRequest req(QUrl("http://download.qt.io/online/qtsdkrepository/windows_x86/root/qt/Updates.xml.mirrorlist"));
 	auto reply = nam->get(req);
 	connect(reply, &QNetworkReply::finished, [=]
 	{


### PR DESCRIPTION
The previous master file on the qtproject domain is now redirecting to qt.io. However QNetworkRequest won't automatically follow such a redirect (see API) and therefore the trivial solution is to replace the URL here. The better solution is to handle the redirect and/or allow overriding the URL from a setting.
