### PR TITLE
add mirror speed test (latency + transfer)

### DIFF
--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -261,28 +261,26 @@ Downloader::getTestFileFromIndex(const QString& rootUrl, const QString& relPath,
             return;
         }
         const QString& filename = wantedFiles.at(0);
-        qDebug() << "filename = " << filename;
-//        for (const QString& filename : wantedFiles)
-//        {
-            QNetworkRequest fileReq(QUrl(rootUrl + relPath + filename));
-            QElapsedTimer latencyTimer;
-            latencyTimer.start();
-            auto fileReply = nam->get(fileReq);
 
-            connect(fileReply, &QNetworkReply::finished, [=]
-            {
-                QByteArray data = fileReply->read(1024 * 1024);
-                qDebug() << "\tDownloading" << (data.size() / 1024) << " KB took" << latencyTimer.elapsed() << " ms";
-                double rate = (data.size() / 1024.0) / (latencyTimer.elapsed() / 1000.0);
-                qDebug() << "- transfer speed: " << rate << "KB/s";
-                fileReply->deleteLater();
-            });
+        // TODO: loop wantedFiles until success instead of only trying first
+        QNetworkRequest fileReq(QUrl(rootUrl + relPath + filename));
+        QElapsedTimer latencyTimer;
+        latencyTimer.start();
+        auto fileReply = nam->get(fileReq);
 
-            connect(fileReply, ( void (QNetworkReply::*)(QNetworkReply::NetworkError) )&QNetworkReply::error, [=]
-            {
-                qDebug() << "\tERROR:" << fileReply->errorString();
-            });
-//        }
+        connect(fileReply, &QNetworkReply::finished, [=]
+        {
+            QByteArray data = fileReply->read(1024 * 1024);
+            qDebug() << "\tDownloading" << (data.size() / 1024) << " KB took" << latencyTimer.elapsed() << " ms";
+            double rate = (data.size() / 1024.0) / (latencyTimer.elapsed() / 1000.0);
+            qDebug() << "- transfer speed: " << rate << "KB/s";
+            fileReply->deleteLater();
+        });
+
+        connect(fileReply, ( void (QNetworkReply::*)(QNetworkReply::NetworkError) )&QNetworkReply::error, [=]
+        {
+            qDebug() << "\tERROR:" << fileReply->errorString();
+        });
     });
 
     connect(indexReply, ( void (QNetworkReply::*)(QNetworkReply::NetworkError) )&QNetworkReply::error, [=]

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -7,6 +7,7 @@
 #include <QNetworkReply>
 #include <QDebug>
 #include <QDir>
+#include <QElapsedTimer>
 
 Downloader::Downloader(QObject* parent)
 	: QObject(parent)
@@ -18,6 +19,8 @@ Downloader::loadMirrors()
 {
 	qDebug() << "Downloading mirror list...";
 
+    QElapsedTimer timer;
+    timer.start();
 	// ASSUMPTION: All mirrors host packages for all architectures
 	// ASSUMPTION: Updates.xml is the core file
 	QNetworkRequest req(QUrl("http://download.qt.io/online/qtsdkrepository/windows_x86/root/qt/Updates.xml.mirrorlist"));
@@ -29,6 +32,7 @@ Downloader::loadMirrors()
 		if (reply->error() != QNetworkReply::NoError)
 			return;
 
+        qDebug() << "Took" << timer.elapsed() / 1000 << "secs";
 		const QStringList mirrorGroups
 		{
 			"mirrors which handle this country", // Country-wide group
@@ -111,6 +115,33 @@ Downloader::useMirror(const QString& sdkArch, const QString& mirrorDomain)
 			{".7z", ".sha1"});
 }
 
+void
+Downloader::testMirrorSpeed(const QString& sdkArch, const QString& mirrorDomain)
+{
+    qDebug() << "Test mirror speed (" << mirrorDomain << ")";
+
+    auto rootUrl = mirrorMap[mirrorDomain];
+
+    QString subdir = "online/qtsdkrepository/" + sdkArch + "/desktop/tools_qtcreator/qt.tools.qtcreator/";
+
+    QNetworkRequest req(QUrl(rootUrl + "timestamp.txt"));
+
+    QElapsedTimer timer;
+    timer.start();
+
+    auto reply = nam->get(req);
+    connect(reply, &QNetworkReply::finished, [=]
+    {
+        qDebug() << "- latency: " << timer.elapsed() << " ms";
+    });
+    connect(reply, ( void (QNetworkReply::*)(QNetworkReply::NetworkError) )&QNetworkReply::error, [=]
+    {
+        qDebug() << "\tERROR:" << reply->errorString();
+    });
+
+    getTestFileFromIndex(rootUrl, subdir, "qtcreator_sdktool.7z");
+
+}
 
 // =======
 // PRIVATE
@@ -198,6 +229,66 @@ Downloader::getFilesFromIndex(const QString& rootUrl, const QString& relPath, co
 	{
 		qDebug() << "\tERROR:" << indexReply->errorString();
 	});
+}
+
+void
+Downloader::getTestFileFromIndex(const QString& rootUrl, const QString& relPath, const QString& wantedExtension)
+{
+    // ASSUMPTION: relPath ends with '/'
+
+    QNetworkRequest indexReq(QUrl(rootUrl + relPath));
+    QNetworkReply* indexReply = nam->get(indexReq);
+    connect(indexReply, &QNetworkReply::finished, [=]
+    {
+
+        QString page = indexReply->readAll();
+        indexReply->deleteLater();
+
+        // ASSUMPTION: There's no whitespace around the '='
+        QStringList links = page.split("a href=\"");
+        links.removeFirst();
+
+        QStringList wantedFiles;
+        for (int i = 0; i < links.size(); ++i)
+        {
+            QString link = links[i].split('"').at(0);
+            if (isWanted(link, {wantedExtension}))
+                wantedFiles << link;
+        }
+
+        if (wantedFiles.size() == 0) {
+            qDebug() << "\tERROR: can't find test file ending with " << wantedExtension;
+            return;
+        }
+        const QString& filename = wantedFiles.at(0);
+        qDebug() << "filename = " << filename;
+//        for (const QString& filename : wantedFiles)
+//        {
+            QNetworkRequest fileReq(QUrl(rootUrl + relPath + filename));
+            QElapsedTimer latencyTimer;
+            latencyTimer.start();
+            auto fileReply = nam->get(fileReq);
+
+            connect(fileReply, &QNetworkReply::finished, [=]
+            {
+                QByteArray data = fileReply->read(1024 * 1024);
+                qDebug() << "\tDownloading" << (data.size() / 1024) << " KB took" << latencyTimer.elapsed() << " ms";
+                double rate = (data.size() / 1024.0) / (latencyTimer.elapsed() / 1000.0);
+                qDebug() << "- transfer speed: " << rate << "KB/s";
+                fileReply->deleteLater();
+            });
+
+            connect(fileReply, ( void (QNetworkReply::*)(QNetworkReply::NetworkError) )&QNetworkReply::error, [=]
+            {
+                qDebug() << "\tERROR:" << fileReply->errorString();
+            });
+//        }
+    });
+
+    connect(indexReply, ( void (QNetworkReply::*)(QNetworkReply::NetworkError) )&QNetworkReply::error, [=]
+    {
+        qDebug() << "\tERROR:" << indexReply->errorString();
+    });
 }
 
 void

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -260,12 +260,13 @@ Downloader::getTestFileFromIndex(const QString& rootUrl, const QString& relPath,
             qDebug() << "\tERROR: can't find test file ending with " << wantedExtension;
             return;
         }
+        // TODO: loop wantedFiles until success instead of only trying first
         const QString& filename = wantedFiles.at(0);
 
-        // TODO: loop wantedFiles until success instead of only trying first
-        QNetworkRequest fileReq(QUrl(rootUrl + relPath + filename));
         QElapsedTimer latencyTimer;
         latencyTimer.start();
+
+        QNetworkRequest fileReq(QUrl(rootUrl + relPath + filename));
         auto fileReply = nam->get(fileReq);
 
         connect(fileReply, &QNetworkReply::finished, [=]

--- a/src/downloader.h
+++ b/src/downloader.h
@@ -23,6 +23,7 @@ signals:
 
 public slots:
 	void useMirror(const QString& sdkArch, const QString& mirrorDomain);
+	void testMirrorSpeed(const QString& sdkArch, const QString& mirrorDomain);
 
 private:
 	QNetworkAccessManager* nam;
@@ -38,6 +39,7 @@ private:
 
 	void initCounters();
 	void getFilesFromIndex(const QString& rootUrl, const QString& relPath, const QStringList& wantedExtensions);
+	void getTestFileFromIndex(const QString& rootUrl, const QString& relPath, const QString& wantedExtension);
 	void recordDownload();
 };
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -37,6 +37,10 @@ Gui::Gui(QWidget* parent)
 		pushButton_mirror->setEnabled(false);
 		emit mirrorSelected(comboBox_os->currentText(), comboBox_mirror->currentText());
 	});
+	connect(pushButton_test, &QPushButton::clicked, [=]
+	{
+		emit mirrorTestReq(comboBox_os->currentText(), comboBox_mirror->currentText());
+	});
 }
 
 void
@@ -45,6 +49,7 @@ Gui::setMirrorList(const QStringList& mirrors)
 	comboBox_mirror->clear();
 	comboBox_mirror->addItems(mirrors);
 	pushButton_mirror->setEnabled(mirrors.count() > 0);
+	pushButton_test->setEnabled(mirrors.count() > 0);
 }
 
 void

--- a/src/gui.h
+++ b/src/gui.h
@@ -19,6 +19,7 @@ public slots:
 
 signals:
 	void mirrorSelected(const QString& sdkArch, const QString& mirrorDomain) const;
+	void mirrorTestReq(const QString& sdkArch, const QString& mirrorDomain) const;
 };
 
 #endif // GUI_H

--- a/src/gui.ui
+++ b/src/gui.ui
@@ -97,6 +97,16 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="1">
+    <widget class="QPushButton" name="pushButton_test">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Test Speed</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,9 @@ int main(int argc, char *argv[])
 	QObject::connect(&gui, &Gui::mirrorSelected,
 			&downloader, &Downloader::useMirror);
 
+	QObject::connect(&gui, &Gui::mirrorTestReq,
+			&downloader, &Downloader::testMirrorSpeed);
+
 	QObject::connect(&downloader, &Downloader::metadataLoaded, [&gui](const QString& sdkArch, const QString& rootUrl)
 	{
 		qDebug() << "Patching Updates.xml...";


### PR DESCRIPTION
Hi

the manual method described in the documentation on how to select a mirror does no longer work. It is not possible anymore to select a mirror manually and test its speed (at least I did not find it in the renewed site).

So I added a button in your program to test a mirror's speed. 

Thanks for the helper program, without it it took me ages to download (and cancelled eventually ;)). Now it is downloaded in the time it took me to create this pull request.